### PR TITLE
EntityDefault+AggField update; BotBonus tab update/insert/delete --wip

### DIFF
--- a/PerpTool/MainWindow.xaml
+++ b/PerpTool/MainWindow.xaml
@@ -54,7 +54,25 @@
                     <Button Content="Save Changes" Margin="274,0,0,0" Click="Button_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="80"/>
                 </StackPanel>
             </TabItem>
-            <TabItem Header="Character / Account Stuff">
+
+                <TabItem Header="Edit Bot Bonuses">
+                    <StackPanel Background="#FFE5E5E5">
+                    <ComboBox x:Name="bot_combo_dropdown" HorizontalAlignment="Left" Margin="10,27,0,0" VerticalAlignment="Top" Width="600" ItemsSource="{Binding BotItems}" DisplayMemberPath="Name" SelectedValuePath="Definition" DropDownClosed="Bot_ComboBox_DropDownClosed"/>
+                        <DataGrid Margin="10,10,10,10" ItemsSource="{Binding BotBonusList}" AutoGenerateColumns="False" CanUserAddRows="False" SelectionChanged="DataGrid_SelectionChanged" VerticalScrollBarVisibility="Visible" Height="186" >
+                            <DataGrid.Columns>
+                            <DataGridTextColumn Header="FieldName" Width="*" Binding="{Binding aggFieldName}" IsReadOnly="True" CellStyle="{StaticResource readonlystyle}"/>
+                            <DataGridTextColumn Header="ExtensionName" Width="*" Binding="{Binding extensionName}" IsReadOnly="True" CellStyle="{StaticResource readonlystyle}"/>
+                            <DataGridTextColumn Header="Bonus per level" Width="100" Binding="{Binding bonus}"/>
+                            <DataGridTextColumn Header="EffectEnchance?" Width="100" Binding="{Binding effectenhancer}"/>
+                        </DataGrid.Columns>
+                        </DataGrid>
+
+                    <Button Content="Save Changes" Margin="274,0,0,0" Click="Bot_Bonus_Save_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="80"/>
+                    </StackPanel>
+                </TabItem>
+
+
+                <TabItem Header="Character / Account Stuff">
                 <Grid Background="#FFE5E5E5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="202*"/>

--- a/PerpTool/MainWindow.xaml
+++ b/PerpTool/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:PerpTool"
         xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero2" x:Class="PerpTool.MainWindow"
         mc:Ignorable="d"
-        Title="The Perpetuum DB Editing Tool - AWESOME Edition" Height="454" Width="655.5" ResizeMode="CanResize">
+        Title="The Perpetuum DB Editing Tool - AWESOME Edition" Height="Auto" Width="655.5" ResizeMode="CanResize">
 
     <Window.Resources>
         <Style x:Key="ColumnHeaderGripperStyle" TargetType="{x:Type Thumb}">
@@ -29,9 +29,18 @@
     <Grid>
         <TabControl Margin="10,0,9.667,9.667">
             <TabItem Header="Edit Item Properties">
-                <Grid Background="#FFE5E5E5">
+                <StackPanel Background="#FFE5E5E5">
                     <ComboBox x:Name="combo" HorizontalAlignment="Left" Margin="10,27,0,0" VerticalAlignment="Top" Width="600" ItemsSource="{Binding EntityItems}" DisplayMemberPath="Name" SelectedValuePath="Definition" DropDownClosed="ComboBox_DropDownClosed"/>
-                    <DataGrid Margin="10,61,10,36" ItemsSource="{Binding FieldValuesList}" AutoGenerateColumns="False" CanUserAddRows="False" SelectionChanged="DataGrid_SelectionChanged" >
+                    <DataGrid Margin="10,10,10,10" ItemsSource="{Binding selectedEntity}" AutoGenerateColumns="False" CanUserAddRows="False" SelectionChanged="DataGrid_SelectionChanged" VerticalScrollBarVisibility="Visible" Height="Auto" >
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="ID" Width="55" Binding="{Binding Definition}" IsReadOnly="True" CellStyle="{StaticResource readonlystyle}"/>
+                            <DataGridTextColumn Header="Name" Width="*" Binding="{Binding Name}" IsReadOnly="True" CellStyle="{StaticResource readonlystyle}"/>
+                            <DataGridTextColumn Header="Mass" Width="55" Binding="{Binding Mass}" />
+                            <DataGridTextColumn Header="Volume" Width="55" Binding="{Binding Volume}"/>
+                            <DataGridTextColumn Header="Options" Width="*" Binding="{Binding Options}"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <DataGrid Margin="10,10,10,10" ItemsSource="{Binding FieldValuesList}" AutoGenerateColumns="False" CanUserAddRows="False" SelectionChanged="DataGrid_SelectionChanged" VerticalScrollBarVisibility="Visible" Height="Auto" >
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Field" Width="250" Binding="{Binding FieldName}" IsReadOnly="True" CellStyle="{StaticResource readonlystyle}"/>
                             <DataGridTextColumn Header="Value" Width="55" Binding="{Binding FieldValue}"/>
@@ -41,8 +50,9 @@
                             <DataGridTextColumn Header="Formula" Width="55" Binding="{Binding FieldFormula}"/>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <Button Content="Save Changes" Margin="274,0,0,0" Click="Button_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="75"/>
-                </Grid>
+
+                    <Button Content="Save Changes" Margin="274,0,0,0" Click="Button_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="80"/>
+                </StackPanel>
             </TabItem>
             <TabItem Header="Character / Account Stuff">
                 <Grid Background="#FFE5E5E5">

--- a/PerpTool/MainWindow.xaml.cs
+++ b/PerpTool/MainWindow.xaml.cs
@@ -61,7 +61,7 @@ namespace PerpTool
             LootableBots = Entities.GetAllNPCLootableBots();
             LootableEntityDefaults = Entities.GetLootableEntities();
 
-
+            this.selectedEntity = new ObservableCollection<EntityItems>();
             this.DataContext = this;
         }
 
@@ -77,6 +77,21 @@ namespace PerpTool
         public NPCLoot Loot { get; set; }
 
         public List<EntityItems> EntityItems { get; set; }
+
+        private ObservableCollection<EntityItems> _selectedEntity;
+        public ObservableCollection<EntityItems> selectedEntity
+        {
+            get
+            {
+                return _selectedEntity;
+            }
+            set
+            {
+                _selectedEntity = value;
+                OnPropertyChanged("selectedEntity");
+            }
+        }
+
 
         private List<FieldValuesStuff> _valstuffs;
         public List<FieldValuesStuff> FieldValuesList
@@ -169,6 +184,8 @@ namespace PerpTool
         private void ComboBox_DropDownClosed(object sender, EventArgs e)
         {
             EntityItems item = (EntityItems)combo.SelectedItem;
+            this.selectedEntity.Clear();
+            this.selectedEntity.Add(item);
             this.currentSelection = item;
             if (item == null) { return; }
             FieldValuesList = AgValues.GetValuesForEntity(item.Definition);
@@ -371,13 +388,14 @@ namespace PerpTool
                         Loot.updateSelf(item);
                         sb.Append(Loot.Save());
                         sb.AppendLine();
-                    }else if(item.recordAction == DBAction.INSERT)
+                    }
+                    else if (item.recordAction == DBAction.INSERT)
                     {
                         Loot.updateSelf(item);
                         sb.Append(Loot.Insert());
                         sb.AppendLine();
                     }
-                    else if(item.recordAction == DBAction.DELETE)
+                    else if (item.recordAction == DBAction.DELETE)
                     {
 
                     }

--- a/PerpTool/MainWindow.xaml.cs
+++ b/PerpTool/MainWindow.xaml.cs
@@ -26,12 +26,6 @@ namespace PerpTool
     public partial class MainWindow : Window, INotifyPropertyChanged
     {
 
-        public class comboitems
-        {
-            int Definition { get; set; }
-            string Name { get; set; }
-        }
-
         private string Connstr = "Server=localhost\\PERPSQL;Database=perpetuumsa;Trusted_Connection=True;Pooling=True;Connection Timeout=30;Connection Lifetime=260;Connection Reset=True;Min Pool Size=20;Max Pool Size=60;";
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -53,6 +47,7 @@ namespace PerpTool
             ZoneTbl = new Zones(Connstr);
             Spawn = new NPCSpawn(Connstr);
             Loot = new NPCLoot(Connstr);
+            BotBonus = new ChassisBonus(Connstr);
 
 
             EntityItems = Entities.GetEntitiesWithFields();
@@ -60,8 +55,11 @@ namespace PerpTool
             SpawnList = Spawn.GetAllSpawns();
             LootableBots = Entities.GetAllNPCLootableBots();
             LootableEntityDefaults = Entities.GetLootableEntities();
+            BotItems = Entities.GetAllDistinctBotItems();
 
             this.selectedEntity = new ObservableCollection<EntityItems>();
+
+
             this.DataContext = this;
         }
 
@@ -75,6 +73,8 @@ namespace PerpTool
         public Zones ZoneTbl { get; set; }
         public NPCSpawn Spawn { get; set; }
         public NPCLoot Loot { get; set; }
+        private ChassisBonus BotBonus { get; set; }
+        public List<EntityItems> BotItems { get; set; }
 
         public List<EntityItems> EntityItems { get; set; }
 
@@ -151,6 +151,20 @@ namespace PerpTool
             }
         }
 
+        private ObservableCollection<BotBonusObj> _botbonuslist;
+        public ObservableCollection<BotBonusObj> BotBonusList
+        {
+            get
+            {
+                return _botbonuslist;
+            }
+            set
+            {
+                _botbonuslist = value;
+                OnPropertyChanged("BotBonusList");
+            }
+        }
+
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
@@ -217,11 +231,6 @@ namespace PerpTool
         {
             EntityItems item = (EntityItems)npcloot.SelectedItem;
             this.currentRowAddItem = item;
-        }
-
-        private void DataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-
         }
 
         private List<NPCSpawn> _spawns;
@@ -409,7 +418,7 @@ namespace PerpTool
                     }
                     else if (item.recordAction == DBAction.DELETE)
                     {
-
+                        //TODO
                     }
                 }
                 File.WriteAllText(AppDomain.CurrentDomain.BaseDirectory + @"\" + currentNPCLootableBot.Name + ".sql", sb.ToString());
@@ -435,6 +444,34 @@ namespace PerpTool
                 MessageBox.Show("Doh! Could not save somthing!\n" + ex.Message, "Error", 0, MessageBoxImage.Error);
             }
 
+        }
+
+
+
+        public EntityItems currentBotComponentSelection;
+        private void Bot_ComboBox_DropDownClosed(object sender, EventArgs e)
+        {
+            EntityItems item = (EntityItems)bot_combo_dropdown.SelectedItem;
+            this.currentBotComponentSelection = item;
+            if (item == null) { return; }
+            this.BotBonusList = BotBonus.getByEntity(item.Definition);
+        }
+
+        private void Bot_Bonus_Save_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                //TODO
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Doh! Could not save somthing!\n" + ex.Message, "Error", 0, MessageBoxImage.Error);
+            }
+
+        }
+
+        private void DataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
         }
     }
 }

--- a/PerpTool/MainWindow.xaml.cs
+++ b/PerpTool/MainWindow.xaml.cs
@@ -461,7 +461,13 @@ namespace PerpTool
         {
             try
             {
-                //TODO
+                StringBuilder sb = new StringBuilder();
+                foreach (BotBonusObj bonus in this.BotBonusList)
+                {
+                    sb.AppendLine(this.BotBonus.Save(bonus));
+                }
+                File.WriteAllText(AppDomain.CurrentDomain.BaseDirectory + @"\" + currentBotComponentSelection.Name + ".sql", sb.ToString());
+                MessageBox.Show("Saved!", "Info", 0, MessageBoxImage.Information);
             }
             catch (Exception ex)
             {

--- a/PerpTool/MainWindow.xaml.cs
+++ b/PerpTool/MainWindow.xaml.cs
@@ -78,6 +78,8 @@ namespace PerpTool
 
         public List<EntityItems> EntityItems { get; set; }
 
+
+        //TODO hack, using observable collection for one item BAD
         private ObservableCollection<EntityItems> _selectedEntity;
         public ObservableCollection<EntityItems> selectedEntity
         {
@@ -170,9 +172,19 @@ namespace PerpTool
                         AgFields.formula = item.FieldFormula;
                         sb.AppendLine(AgFields.Save());
                     }
-                    Console.WriteLine(sb.ToString());
-                    File.WriteAllText(AppDomain.CurrentDomain.BaseDirectory + @"\" + currentSelection.Name + ".sql", sb.ToString());
+
                 }
+
+                if (selectedEntity.Count == 1) //TODO hack -- impl object that is observable by gui framework
+                {
+                    foreach (EntityItems eItem in this.selectedEntity)
+                    {
+                        sb.AppendLine(Entities.SaveWithEntityItemChange(eItem));
+                    }
+                }
+
+                Console.WriteLine(sb.ToString());
+                File.WriteAllText(AppDomain.CurrentDomain.BaseDirectory + @"\" + currentSelection.Name + ".sql", sb.ToString());
                 MessageBox.Show("Saved!", "Info", 0, MessageBoxImage.Information);
             }
             catch (Exception ex)

--- a/PerpTool/PerpTool.csproj
+++ b/PerpTool/PerpTool.csproj
@@ -68,6 +68,7 @@
     <Compile Include="db\AggregateModifiers.cs" />
     <Compile Include="db\AggregateValues.cs" />
     <Compile Include="db\Characters.cs" />
+    <Compile Include="db\ChassisBonus.cs" />
     <Compile Include="db\NPCLoot.cs" />
     <Compile Include="db\EntityDefaults.cs" />
     <Compile Include="db\NPCSpawn.cs" />

--- a/PerpTool/db/AggregateModifiers.cs
+++ b/PerpTool/db/AggregateModifiers.cs
@@ -167,39 +167,6 @@ namespace Perptool.db
             }
         }
 
-        ///// <summary>
-        ///// gets a record by its record id
-        ///// </summary>
-        ///// <param name='id number'>id number</param>
-        //public void GetById(int categoryflag)
-        //{
-        //    SqlConnection conn = new SqlConnection(this.ConnString);
-        //    using (SqlCommand command = new SqlCommand())
-        //    {
-        //        StringBuilder sqlCommand = new StringBuilder();
-        //        sqlCommand.Append("SELECT * from aggregatemodifiers Where categoryflag=@categoryflag");
-        //        command.CommandText = sqlCommand.ToString();
-        //        command.Parameters.AddWithValue("@categoryflag", categoryflag);
-        //        command.Connection = conn;
-        //        conn.Open();
-        //        using (SqlDataReader reader = command.ExecuteReader())
-        //        {
-        //            while (reader.Read())
-        //            {
-        //                this.categoryflag = Convert.ToInt32(reader["categoryflag"]);
-        //                this.basefield = Convert.ToInt32(reader["basefield"]);
-        //                this.modifierfield = Convert.ToInt32(reader["modifierfield"]);
-        //            }
-        //        }
-
-        //        conn.Dispose();
-        //    }
-        //}
-
-        /// <summary>
-        /// fires when properties are set.
-        /// </summary>
-        /// <param name='name'>name of property being changed</param>
         protected void OnPropertyChanged(string name)
         {
             this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));

--- a/PerpTool/db/ChassisBonus.cs
+++ b/PerpTool/db/ChassisBonus.cs
@@ -127,7 +127,7 @@ namespace Perptool.db
             }
         }
 
-        public int effectenchancer
+        public int effectenhancer
         {
             get
             {
@@ -153,7 +153,7 @@ namespace Perptool.db
             this.bonus = 0;
             this.note = string.Empty;
             this.targetpropertyID = 0;
-            this.effectenchancer = 0;
+            this.effectenhancer = 0;
         }
 
         public ObservableCollection<BotBonusObj> getByEntity(int definitionID)
@@ -196,18 +196,17 @@ namespace Perptool.db
         }
 
 
-        public string Save()//TODO not impl'd
+        public string Save(BotBonusObj bonusChanges)
         {
             string query = "";
             using (SqlCommand command = new SqlCommand())
             {
                 StringBuilder sqlCommand = new StringBuilder();
-                sqlCommand.Append("UPDATE aggregatevalues SET definition=@definition, field=@field, value=@value WHERE id = @id");
+                sqlCommand.Append("UPDATE chassisbonus SET effectenhancer=@effectenhancer, bonus=@bonus WHERE id = @id");
                 command.CommandText = sqlCommand.ToString();
-                command.Parameters.AddWithValue("@id", this.id);
-                command.Parameters.AddWithValue("@definition", this.definition);
-              //  command.Parameters.AddWithValue("@field", this.field);
-              //  command.Parameters.AddWithValue("@value", this.value);
+                command.Parameters.AddWithValue("@id", bonusChanges.id);
+                command.Parameters.AddWithValue("@bonus", bonusChanges.bonus);
+                command.Parameters.AddWithValue("@effectenhancer", bonusChanges.effectenhancer);
 
                 SqlConnection conn = new SqlConnection(this.ConnString);
                 conn.Open();

--- a/PerpTool/db/ChassisBonus.cs
+++ b/PerpTool/db/ChassisBonus.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Data.SqlClient;
+using System.IO;
+using System.Text;
+
+namespace Perptool.db
+{
+    public class BotBonusObj
+    {
+        public int id { get; set; }
+        public int definition { get; set; }
+        public int extension { get; set; }
+        public decimal bonus { get; set; }
+        public string note { get; set; }
+        public int targetpropertyID { get; set; }
+        public int effectenhancer { get; set; }
+        public string definitionName { get; set; }
+        public string extensionName { get; set; }
+        public string aggFieldName { get; set; }
+    }
+
+
+    class ChassisBonus : INotifyPropertyChanged
+    {
+        private int privateid;
+        private int privatedefinition;
+        private int privateextension;
+        private decimal privatebonus;
+        private string privatenote;
+        private int privatetargetpropertyID;
+        private int privateeffectenhancer;
+
+        public ChassisBonus(string connectionString)
+        {
+            this.ConnString = connectionString;
+        }
+
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        #region Fields
+
+        public int id
+        {
+            get
+            {
+                return this.privateid;
+            }
+
+            set
+            {
+                this.privateid = value;
+                this.OnPropertyChanged("id");
+            }
+        }
+
+        public int definition
+        {
+            get
+            {
+                return this.privatedefinition;
+            }
+
+            set
+            {
+                this.privatedefinition = value;
+                this.OnPropertyChanged("definition");
+            }
+        }
+
+        public int extension
+        {
+            get
+            {
+                return this.privateextension;
+            }
+
+            set
+            {
+                this.privateextension = value;
+                this.OnPropertyChanged("extension");
+            }
+        }
+
+        public decimal bonus
+        {
+            get
+            {
+                return this.privatebonus;
+            }
+
+            set
+            {
+                this.privatebonus = value;
+                this.OnPropertyChanged("bonus");
+            }
+        }
+
+        public string note
+        {
+            get
+            {
+                return this.privatenote;
+            }
+
+            set
+            {
+                this.privatenote = value;
+                this.OnPropertyChanged("note");
+            }
+        }
+
+        public int targetpropertyID
+        {
+            get
+            {
+                return this.privatetargetpropertyID;
+            }
+
+            set
+            {
+                this.privatetargetpropertyID = value;
+                this.OnPropertyChanged("targetpropertyID");
+            }
+        }
+
+        public int effectenchancer
+        {
+            get
+            {
+                return this.privateeffectenhancer;
+            }
+
+            set
+            {
+                this.privateeffectenhancer = value;
+                this.OnPropertyChanged("effectenchancer");
+            }
+        }
+
+        private string ConnString { get; set; }
+
+        #endregion
+
+        public void Clear()
+        {
+            this.id = 0;
+            this.definition = 0;
+            this.extension = 0;
+            this.bonus = 0;
+            this.note = string.Empty;
+            this.targetpropertyID = 0;
+            this.effectenchancer = 0;
+        }
+
+        public ObservableCollection<BotBonusObj> getByEntity(int definitionID)
+        {
+            ObservableCollection<BotBonusObj> list = new ObservableCollection<BotBonusObj>();
+            using (SqlConnection conn = new SqlConnection(this.ConnString))
+            {
+                using (SqlCommand command = new SqlCommand())
+                {
+                    StringBuilder sqlCommand = new StringBuilder();
+                    sqlCommand.Append(@"SELECT chassisbonus.id,chassisbonus.definition,chassisbonus.extension,chassisbonus.note,chassisbonus.targetpropertyID,chassisbonus.bonus,
+                    chassisbonus.effectenhancer,entitydefaults.definitionname,extensions.extensionname,aggregatefields.name
+                    FROM chassisbonus JOIN entitydefaults on chassisbonus.definition=entitydefaults.definition JOIN extensions on extensions.extensionid=chassisbonus.extension
+                    JOIN aggregatefields on aggregatefields.id=chassisbonus.targetpropertyID WHERE entitydefaults.definition=@id;");
+                    command.CommandText = sqlCommand.ToString();
+                    command.Parameters.AddWithValue("@id", definitionID);
+                    command.Connection = conn;
+                    conn.Open();
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            BotBonusObj tmp = new BotBonusObj();
+                            tmp.id = Convert.ToInt32(reader["id"]);
+                            tmp.definition = Convert.ToInt32(reader["definition"]);
+                            tmp.extension = Convert.ToInt32(reader["extension"]);
+                            tmp.bonus = Convert.ToDecimal(reader["bonus"]);
+                            tmp.note = Convert.ToString(reader["note"]);
+                            tmp.targetpropertyID = Convert.ToInt32(reader["targetpropertyID"]);
+                            tmp.effectenhancer = Convert.ToInt32(reader["effectenhancer"]);
+                            tmp.definitionName = Convert.ToString(reader["definitionname"]);
+                            tmp.extensionName = Convert.ToString(reader["extensionname"]);
+                            tmp.aggFieldName = Convert.ToString(reader["name"]);
+                            list.Add(tmp);
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+
+
+        public string Save()//TODO not impl'd
+        {
+            string query = "";
+            using (SqlCommand command = new SqlCommand())
+            {
+                StringBuilder sqlCommand = new StringBuilder();
+                sqlCommand.Append("UPDATE aggregatevalues SET definition=@definition, field=@field, value=@value WHERE id = @id");
+                command.CommandText = sqlCommand.ToString();
+                command.Parameters.AddWithValue("@id", this.id);
+                command.Parameters.AddWithValue("@definition", this.definition);
+              //  command.Parameters.AddWithValue("@field", this.field);
+              //  command.Parameters.AddWithValue("@value", this.value);
+
+                SqlConnection conn = new SqlConnection(this.ConnString);
+                conn.Open();
+                command.Connection = conn;
+                command.ExecuteNonQuery();
+                conn.Close();
+                query = command.CommandText;
+                foreach (SqlParameter p in command.Parameters)
+                {
+                    query = query.Replace(p.ParameterName, p.Value.ToString());
+                }
+            }
+            return query;
+        }
+
+
+
+        protected void OnPropertyChanged(string name)
+        {
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/PerpTool/db/EntityDefaults.cs
+++ b/PerpTool/db/EntityDefaults.cs
@@ -12,10 +12,30 @@ namespace Perptool.db
 
     // THI IS SHIT. don't hate!
 
-    public class EntityItems
+    public class EntityItems : INotifyPropertyChanged
     {
         public int Definition { get; set; }
         public string Name { get; set; }
+        public string Options { get; set; }
+        // public string Note { get; set; }
+        // public int Enabled { get; set; }
+        public int Volume { get; set; }
+        public int Mass { get; set; }
+        //  public int Hidden { get; set; }
+        // public int Health { get; set; }
+        // public string DescriptionToken { get; set; }
+        //public int Purchasable { get; set; }
+        //public int TierType { get; set; }
+        // public int TierLevel { get; set; }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged(string name)
+        {
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+
     }
 
     /// <summary>
@@ -548,7 +568,9 @@ namespace Perptool.db
             using (SqlCommand command = new SqlCommand())
             {
                 StringBuilder sqlCommand = new StringBuilder();
-                sqlCommand.Append("SELECT entitydefaults.definition, entitydefaults.definitionname FROM entitydefaults JOIN aggregatevalues ON (aggregatevalues.definition = entitydefaults.definition) GROUP BY entitydefaults.definition,  entitydefaults.definitionname");
+                sqlCommand.Append(@"SELECT entitydefaults.definition, entitydefaults.definitionname, entitydefaults.mass, entitydefaults.volume, entitydefaults.options
+                FROM entitydefaults JOIN aggregatevalues ON (aggregatevalues.definition = entitydefaults.definition) 
+                GROUP BY entitydefaults.definition, entitydefaults.definitionname, entitydefaults.mass, entitydefaults.volume, entitydefaults.options");
                 command.CommandText = sqlCommand.ToString();
                 command.Connection = conn;
                 conn.Open();
@@ -559,12 +581,17 @@ namespace Perptool.db
                         EntityItems item = new EntityItems();
                         item.Name = Convert.ToString(reader["definitionname"]);
                         item.Definition = Convert.ToInt32(reader["definition"]);
+                        item.Options = Convert.ToString(reader["options"]);
+                        item.Volume = Convert.ToInt32(reader["volume"]);
+                        item.Mass = Convert.ToInt32(reader["mass"]);
                         list.Add(item);
                     }
                 }
             }
             return list;
         }
+
+
 
 
         public List<EntityItems> GetAllNPCLootableBots()

--- a/PerpTool/db/EntityDefaults.cs
+++ b/PerpTool/db/EntityDefaults.cs
@@ -450,7 +450,7 @@ namespace Perptool.db
             {
                 StringBuilder sqlCommand = new StringBuilder();
                 sqlCommand.Append("Insert into entitydefaults ");
-                sqlCommand.Append("(`definition`, `definitionname`, `quantity`, `attributeflags`, `categoryflags`, `options`, `note`, `enabled`, `volume`, `mass`, `hidden`, `health`, `descriptiontoken`, `purchasable`, `tiertype`, `tierlevel`) ");
+                sqlCommand.Append("( definition ,  definitionname ,  quantity ,  attributeflags ,  categoryflags ,  options ,  note ,  enabled ,  volume ,  mass ,  hidden ,  health ,  descriptiontoken ,  purchasable ,  tiertype ,  tierlevel ) ");
                 sqlCommand.Append(" Values ");
                 sqlCommand.Append("(@definition, @definitionname, @quantity, @attributeflags, @categoryflags, @options, @note, @enabled, @volume, @mass, @hidden, @health, @descriptiontoken, @purchasable, @tiertype, @tierlevel) ");
 
@@ -489,7 +489,7 @@ namespace Perptool.db
             using (SqlCommand command = new SqlCommand())
             {
                 StringBuilder sqlCommand = new StringBuilder();
-                sqlCommand.Append("UPDATE entitydefaults Set `definitionname`= @definitionname, `quantity`= @quantity, `attributeflags`= @attributeflags, `categoryflags`= @categoryflags, `options`= @options, `note`= @note, `enabled`= @enabled, `volume`= @volume, `mass`= @mass, `hidden`= @hidden, `health`= @health, `descriptiontoken`= @descriptiontoken, `purchasable`= @purchasable, `tiertype`= @tiertype, `tierlevel`= @tierlevel where definition = @definition");
+                sqlCommand.Append("UPDATE entitydefaults Set  definitionname = @definitionname,  quantity = @quantity,  attributeflags = @attributeflags,  categoryflags = @categoryflags,  options = @options,  note = @note,  enabled = @enabled,  volume = @volume,  mass = @mass,  hidden = @hidden,  health = @health,  descriptiontoken = @descriptiontoken,  purchasable = @purchasable,  tiertype = @tiertype,  tierlevel = @tierlevel where definition = @definition");
 
                 command.CommandText = sqlCommand.ToString();
 
@@ -558,6 +558,52 @@ namespace Perptool.db
 
                 conn.Dispose();
             }
+        }
+
+
+        public string SaveWithEntityItemChange(EntityItems item)
+        {
+            string query = "";
+            using (SqlCommand command = new SqlCommand())
+            {
+                StringBuilder sqlCommand = new StringBuilder();
+                sqlCommand.Append("UPDATE entitydefaults SET options=@options, volume=@volume, mass=@mass WHERE definition=@definition");
+
+                command.CommandText = sqlCommand.ToString();
+
+                command.Parameters.AddWithValue("@definition", item.Definition);
+                command.Parameters.AddWithValue("@options", item.Options);
+                command.Parameters.AddWithValue("@volume", item.Volume);
+                command.Parameters.AddWithValue("@mass", item.Mass);
+
+                SqlConnection conn = new SqlConnection(this.ConnString);
+                conn.Open();
+                command.Connection = conn;
+                command.ExecuteNonQuery();
+                conn.Close();
+
+                if (this.note == null)
+                {
+                    command.Parameters.AddWithValue("@note", string.Empty);
+                }
+                else
+                {
+                    command.Parameters.AddWithValue("@note", this.note);
+                }
+                query = command.CommandText;
+                foreach (SqlParameter p in command.Parameters)
+                {
+                    if (SqlDbType.NVarChar.Equals(p.SqlDbType) || SqlDbType.VarChar.Equals(p.SqlDbType))
+                    {
+                        query = query.Replace(p.ParameterName, "'" + p.Value.ToString() + "'");
+                    }
+                    else
+                    {
+                        query = query.Replace(p.ParameterName, p.Value.ToString());
+                    }
+                }
+            }
+            return query;
         }
 
         public List<EntityItems> GetEntitiesWithFields()

--- a/PerpTool/db/EntityDefaults.cs
+++ b/PerpTool/db/EntityDefaults.cs
@@ -693,6 +693,32 @@ namespace Perptool.db
             return list;
         }
 
+        public List<EntityItems> GetAllDistinctBotItems()
+        {
+            List<EntityItems> list = new List<EntityItems>();
+
+            SqlConnection conn = new SqlConnection(this.ConnString);
+            using (SqlCommand command = new SqlCommand())
+            {
+                StringBuilder sqlCommand = new StringBuilder();
+                sqlCommand.Append("SELECT DISTINCT dbo.entitydefaults.definitionname, dbo.entitydefaults.definition FROM dbo.entitydefaults JOIN dbo.chassisbonus on dbo.chassisbonus.definition = dbo.entitydefaults.definition GROUP BY entitydefaults.definition,  entitydefaults.definitionname");
+                command.CommandText = sqlCommand.ToString();
+                command.Connection = conn;
+                conn.Open();
+                using (SqlDataReader reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        EntityItems item = new EntityItems();
+                        item.Name = Convert.ToString(reader["definitionname"]);
+                        item.Definition = Convert.ToInt32(reader["definition"]);
+                        list.Add(item);
+                    }
+                }
+            }
+            return list;
+        }
+
         /// <summary>
         /// fires when properties are set.
         /// </summary>


### PR DESCRIPTION
Because many attributes are still buried in the Options GenXY string or volume/mass of the item still matters for balancing/content team members, this has now been exposed and is editable and savable in the same manner as the AggregateValue/Field updates